### PR TITLE
add golangci-lint

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -63,3 +63,12 @@
   language: script
   files: \.go$
   exclude: vendor\/.*$
+
+# https://github.com/golangci/golangci-lint
+- id: golangci-lint
+  name: golangci-lint
+  description: Linters Runner for Go.
+  entry: pre_commit_hooks/go/golangci-lint.sh
+  language: script
+  files: \.go$
+  exclude: vendor\/.*$

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://i.imgur.com/t8IkKoZl.png" width="200"/>
 
 [![Maintained by Mineiros.io](https://img.shields.io/badge/maintained%20by-mineiros.io-00607c.svg)](https://www.mineiros.io/ref=pre-commit-hooks)
+[![Build Status](https://mineiros.semaphoreci.com/badges/build-tools/branches/master.svg?style=shields)](https://mineiros.semaphoreci.com/projects/build-tools)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/mineiros-io/pre-commit-hooks.svg?label=latest&sort=semver)](https://github.com/mineiros-io/pre-commit-hooks/releases)
 [![License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 
@@ -20,10 +21,12 @@ to the configuration and not accessing any remote services such as remote state,
 all Terraform configuration `*.tf` files.
 
 **Go**
-- gofmt: go fmt is a tool that automatically formats Go `*.go` files to canonical format and style..
+- gofmt: go fmt is a tool that automatically formats Go `*.go` files to canonical format and style.
 - goimports: The goimports command updates import lines in Go `*.go` files, adding missing ones and removing
 unreferenced ones.
 - golint: Golint is a linter that formats your Go `*.go` files.
+- golangci-lint: GolangCI-Lint is a linters aggregator. It's fast: on average 5 times faster than gometalinter.
+  It's easy to integrate and use, has nice output and has a minimum number of false positives.
 
 ## Installation & Dependencies
 Install [pre-commit](https://pre-commit.com/). E.g. `brew install pre-commit`

--- a/README.md
+++ b/README.md
@@ -13,20 +13,23 @@ This repository is a collection of Git hooks to be used with the
 Currently, the following hooks are supported:
 
 **Terraform**
-- terraform-fmt: The terraform fmt command is used to rewrite Terraform configuration `*.tf` files to a canonical format
-and style.
-- terraform-validate: The terraform validate command validates all Terraform configuration `*.tf` files, referring only
-to the configuration and not accessing any remote services such as remote state, provider APIs, etc.
-- tflint: TFLint is a Terraform linter focused on possible errors, best practices, etc. (Terraform >= 0.12). Applied to
-all Terraform configuration `*.tf` files.
+- [terraform-fmt](https://www.terraform.io/docs/commands/fmt.html): The terraform fmt command is used to rewrite
+  Terraform configuration `*.tf` files to a canonical format and style.
+- [terraform-validate](https://www.terraform.io/docs/commands/validate.html): The terraform validate command validates
+  all Terraform configuration `*.tf` files, referring only to the configuration and not accessing any remote services
+  such as remote state, provider APIs, etc.
+- [tflint](https://github.com/terraform-linters/tflint): TFLint is a Terraform linter focused on possible errors, best
+  practices, etc. (Terraform >= 0.12). Applied to all Terraform configuration `*.tf` files.
 
 **Go**
-- gofmt: go fmt is a tool that automatically formats Go `*.go` files to canonical format and style.
-- goimports: The goimports command updates import lines in Go `*.go` files, adding missing ones and removing
-unreferenced ones.
-- golint: Golint is a linter that formats your Go `*.go` files.
-- golangci-lint: GolangCI-Lint is a linters aggregator. It's fast: on average 5 times faster than gometalinter.
-  It's easy to integrate and use, has nice output and has a minimum number of false positives.
+- [gofmt](https://golang.org/cmd/gofmt/): go fmt is a tool that automatically formats Go `*.go` files to canonical
+  format and style.
+- [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports): The goimports command updates import lines in Go
+  `*.go` files, adding missing ones and removing unreferenced ones.
+- [golint](https://github.com/golang/lint): Golint is a linter that formats your Go `*.go` files.
+- [golangci-lint](https://github.com/golangci/golangci-lint): GolangCI-Lint is a linters aggregator.
+  It's fast: on average 5 times faster than gometalinter. It's easy to integrate and use, has nice output and has a
+  minimum number of false positives.
 
 ## Installation & Dependencies
 Install [pre-commit](https://pre-commit.com/). E.g. `brew install pre-commit`

--- a/pre_commit_hooks/go/goimports.sh
+++ b/pre_commit_hooks/go/goimports.sh
@@ -6,6 +6,4 @@ set -e
 # https://stackoverflow.com/q/135688/483528
 export PATH=$PATH:/usr/local/bin
 
-for file in "$@"; do
-  goimports -l -e -w "$(dirname "$file")"
-done
+golangci-lint run "$@"

--- a/pre_commit_hooks/go/golangci-lint.sh
+++ b/pre_commit_hooks/go/golangci-lint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Make environment variables working in OSX GUI apps such as Github Desktop
+# https://stackoverflow.com/q/135688/483528
+export PATH=$PATH:/usr/local/bin
+
+if hash golangci-lint 2>/dev/null; then
+    golangci-lint run --enable-all --fix "$@"
+else
+    echo "Couldn't find golangci-lint executable in your $PATH. Seems like golangci-lint isn't installed." && exit 1
+fi


### PR DESCRIPTION
This PR adds [golangci-lint](https://github.com/golangci/golangci-lint) as a pre-commit hook.

> GolangCI-Lint is a linters aggregator. It's fast: on average 5 times faster than gometalinter. It's easy to >integrate and use, has nice output and has a minimum number of false positives. It supports go >modules.

GolangCI-Lint aggregates the most popular linters. It's configurable and faster to use instead of using each linter on its own. It could be therefore a replacement or alternative for our `gofmt`, `goimports` and `golint` hooks.

