### PR TITLE
Don't pass single filenames to golangci-lint so it doesn't run in parallel

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -70,8 +70,9 @@
   description: Linters Runner for Go.
   entry: pre_commit_hooks/go/golangci-lint.sh
   language: script
-  files: \.go$
-  exclude: vendor\/.*$
+  types: [go]
+  # We can't invoke single files golangci-lint since it expects go packages instead of single files
+  pass_filenames: false
 
 # ---------------------------------------------------------------------------------------------------------------------
 # GNU Make specific hooks


### PR DESCRIPTION
Per default, pre-commit passes a list of modified files to the called hook. This means that e.g. all modified `*.go` files are processed as a list and then piped one-by-one to the target pre-commit hook. `golangci-lint` comes with a lockfile per default and is not meant to run multiple instances in parallel. Instead of passing each modified file to `golangci-lint`, the recommended approach is to just run it without passing any explicit files. This won't affect local environments either since it comes with internal caching.

This PR will fix occurring issues in CI such as https://github.com/mineiros-io/terraform-aws-route53/pull/33.

<img width="1699" alt="Screenshot 2020-07-18 at 23 22 19" src="https://user-images.githubusercontent.com/930643/87862182-8d639580-c94d-11ea-9e68-b5c475103928.png">
