### PR TITLE
Proposal: Implement flag for markdown-lint-check to always pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ repos:
       - id: golangci-lint
       - id: phony-targets
       - id: markdown-link-check
+        args: [-p] # When adding the -p flag, markdown-link-check will always with an exit code 0, even if dead links are found
       - id: shellcheck
 
       # The following hooks are redundant when golangci-lint is being. Our recommendation is to use golangci-lint

--- a/pre_commit_hooks/markdown/markdown-link-check.sh
+++ b/pre_commit_hooks/markdown/markdown-link-check.sh
@@ -8,8 +8,18 @@ if ! command -v markdown-link-check >/dev/null 2>&1; then
   exit 1
 fi
 
+while getopts ':p' 'OPTKEY'; do
+  case ${OPTKEY} in
+    'p') set +e ;;
+    *)
+        echo "unimplemented option -- ${OPTKEY}" >&2
+        exit 1
+        ;;
+  esac
+done
+
 TMP_CONFIG="$(mktemp)"
-trap "rm -f $TMP_CONFIG;" EXIT
+trap 'rm -f $TMP_CONFIG;' EXIT
 
 cat >"$TMP_CONFIG" <<EOF
 {
@@ -25,3 +35,5 @@ EOF
 for file in "$@"; do
   markdown-link-check -c "$TMP_CONFIG" "$file"
 done
+
+exit 0


### PR DESCRIPTION
This PR proposes the implementation of the `-p` which will enable a trap in the `markdown-lint-check` pre-commit bash script to always return an exit code of 0 even if dead links are found. The idea is, that markdown-ci-lint shouldn't break the CI or local pre-commit flow but still be useful for the developer to detect dead links.