### PR TITLE
feat: add support for recursive terradoc `fmt` and `generate`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,13 +1,17 @@
-# Configuring our pre-commit hooks to be used with pre-commit: https://pre-commit.com/
+# Configuring our pre-commit hooks to be used with https://pre-commit.com/
 
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Terraform specific hooks
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 # https://www.terraform.io/docs/commands/fmt.html
 - id: terraform-fmt
   name: Terraform fmt
-  description: The terraform fmt command is used to rewrite Terraform configuration files to a canonical format and style. This command applies a subset of the Terraform language style conventions, along with other minor adjustments for readability.
+  description: |
+    The terraform fmt command is used to rewrite Terraform configuration files
+    to a canonical format and style. This command applies a subset of the
+    Terraform language style conventions, along with other minor adjustments for
+    readability.
   entry: pre_commit_hooks/terraform/fmt.sh
   language: script
   files: \.tf$
@@ -17,7 +21,10 @@
 # https://www.terraform.io/docs/commands/validate.html
 - id: terraform-validate
   name: Terraform validate
-  description: The terraform validate command validates all Terraform configuration files, referring only to the configuration and not accessing any remote services such as remote state, provider APIs, etc.
+  description: |
+    The terraform validate command validates all Terraform configuration files,
+    referring only to the configuration and not accessing any remote services
+    such as remote state, provider APIs, etc.
   entry: pre_commit_hooks/terraform/validate.sh
   language: script
   files: \.tf$
@@ -27,15 +34,17 @@
 # https://github.com/terraform-linters/tflint
 - id: tflint
   name: tflint
-  description: TFLint is a Terraform linter focused on possible errors, best practices, etc. (Terraform >= 0.12)
+  description: |
+    TFLint is a Terraform linter focused on possible errors, best practices,
+    etc. (Terraform >= 0.12)
   entry: pre_commit_hooks/terraform/tflint.sh
   language: script
   files: \.tf$
   exclude: \.+.terraform\/.*$
 
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Golang specific hooks
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 # https://golang.org/cmd/gofmt
 - id: gofmt
@@ -49,7 +58,9 @@
 # https://godoc.org/golang.org/x/tools/cmd/goimports
 - id: goimports
   name: goimports
-  description: Command goimports updates your Go import lines, adding missing ones and removing unreferenced ones.
+  description: |
+    Command goimports updates your Go import lines, adding missing ones and
+    removing unreferenced ones.
   entry: pre_commit_hooks/go/goimports.sh
   language: script
   files: \.go$
@@ -62,12 +73,13 @@
   entry: pre_commit_hooks/go/golangci-lint.sh
   language: script
   types: [go]
-  # We can't invoke single files golangci-lint since it expects go packages instead of single files
+  # We can't invoke single files golangci-lint since it expects go packages
+  # instead of single files
   pass_filenames: false
 
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # GNU Make specific hooks
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 # Validate targets that are marked as PHONY
 - id: phony-targets
@@ -82,14 +94,16 @@
       .+\.terraform\/.*$|
     )$
 
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Markdown specific hooks
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 # https://github.com/tcort/markdown-link-check
 - id: markdown-link-check
   name: markdown-link-check
-  description: Markdown-link-check checks all of the hyperlinks in a markdown text to determine if they are alive or dead.
+  description: |
+    Markdown-link-check checks all of the hyperlinks in a markdown text to
+    determine if they are alive or dead.
   entry: pre_commit_hooks/markdown/markdown-link-check.sh
   language: script
   files: \.md$
@@ -99,14 +113,16 @@
       .+\.terraform\/.*$|
     )$
 
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Bash specific hooks
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 # https://github.com/koalaman/shellcheck
 - id: shellcheck
   name: shellcheck
-  description: ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts.
+  description: |
+    ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh
+    shell scripts.
   entry: pre_commit_hooks/shell/shellcheck.sh
   language: script
   files: \.sh$
@@ -116,49 +132,70 @@
       .+\.terraform\/.*$|
     )$
 
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Terradoc specific hooks
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 - id: terradoc-fmt
   name: Terradoc fmt
-  description: The terradoc fmt command is used to rewrite Terradoc input files to a canonical format and style. This command applies a subset of the Terraform language style conventions, along with other minor adjustments for readability similarly to the corresponding terraform hook.
+  description: |
+    The terradoc fmt command is used to rewrite Terradoc input files to a
+    canonical format and style. This command applies a subset of the Terraform
+    language style conventions, along with other minor adjustments for
+    readability similarly to the corresponding terraform hook.
   entry: pre_commit_hooks/terradoc/fmt.sh
   language: script
-  args:
-    - README.tfdoc.hcl
+  require_serial: true
+  files: ^(.*).tfdoc.hcl$
+  exclude: >
+    (?x)^(
+      .+\.vendor\/.*$|
+      .+\.terraform\/.*$|
+    )$
 
 - id: terradoc-generate
   name: Terradoc generate
-  description: The terradoc generate command is used to generate documentation files from a Terradoc input file.
+  description: |
+    The terradoc generate command is used to generate documentation files from a
+    Terradoc input file.
   entry: pre_commit_hooks/terradoc/generate.sh
   language: script
-  args:
-    - README.tfdoc.hcl
-    - README.md
+  require_serial: true
+  files: ^(.*).tfdoc.hcl$
+  exclude: >
+    (?x)^(
+      .+\.vendor\/.*$|
+      .+\.terraform\/.*$|
+    )$
 
 - id: terradoc-validate
   name: Terradoc validate
-  description: The terradoc validate command is used to validate documentation variables and outputs against .tf files in the same directory.
+  description: |
+    The terradoc validate command is used to validate documentation variables
+    and outputs against .tf files in the same directory.
   entry: pre_commit_hooks/terradoc/validate.sh
   language: script
+  files: ^README.tfdoc.hcl$
   args:
     - README.tfdoc.hcl
-
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Terramate specific hooks
-# ---------------------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
 - id: terramate-generate
   name: Terramate generate
-  description: The terramate generate command is used to generate code from Terramate configuration.
+  description: |
+    The terramate generate command is used to generate code from Terramate
+    configuration.
   entry: pre_commit_hooks/terramate/generate.sh
   language: script
   pass_filenames: false
 
 - id: terramate-fmt
   name: Terramate fmt
-  description: The terramate generate command is used to format Terramate configuration code.
+  description: |
+    The terramate generate command is used to format Terramate configuration
+    code.
   entry: pre_commit_hooks/terramate/fmt.sh
   language: script
   pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -76,17 +76,19 @@ Currently, the following hooks are supported:
 
 ### Terradoc
 
-- terradoc-fmt: The terradoc fmt command is used to rewrite
-  Terradoc configuration `*tfdoc.hcl` files to a canonical format and style.
-- terradoc-validate: The terradoc fmt command is used validate
-  Terradoc configuration `*tfdoc.hcl` files.
-- terradoc-generate: The terradoc generate command generates a documentation file from
-  Terradoc configuration `*tfdoc.hcl` files.
+- [terradoc-fmt](https://github.com/mineiros-io/terradoc): The terradoc fmt command is used to rewrite Terradoc
+    configuration configuration `*.tfdoc.hcl` files to a canonical format and
+    style.
+- [terradoc-generate](https://github.com/mineiros-io/terradoc): The terradoc generate command generates a markdown document
+    from Terradoc configuration `*.tfdoc.hcl` files.
+- [terradoc-validate](https://github.com/mineiros-io/terradoc): The terradoc validate command is used validate Terradoc
+    configuration in `README.tfdoc.hcl` file against Terraform variable
+    definitions.
 
 ### Terramate
 
-- terramate-fmt: The terramate generate command formats code in Terramate configuration files.
-- terramate-generate: The terramate generate command generates code from Terramate configuration files.
+- [terramate-fmt](https://github.com/mineiros-io/terramate): The terramate generate command formats code in Terramate configuration files.
+- [terramate-generate](https://github.com/mineiros-io/terramate): The terramate generate command generates code from Terramate configuration files.
 
 ## Installation & Dependencies
 

--- a/pre_commit_hooks/terradoc/fmt.sh
+++ b/pre_commit_hooks/terradoc/fmt.sh
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
 
 set -e
+set -u 
+set -o pipefail
 
-if ! command -v terradoc >/dev/null 2>&1; then
-  echo >&2 "terradoc is not available on this system."
-  echo >&2 "Please install it by running 'go install github.com/mineiros-io/terradoc/cmd/terradoc@latest'"
-  exit 1
-fi
+# shellcheck disable=SC2155,SC2034
+readonly ARGS=("$@")
 
-terradoc fmt $1 -w
+function is_binary_available() {
+  local bin_list=( terradoc )
+  for b in "${bin_list[@]}"; do
+    if [ -x "$(type -p "${b}")" ]; then
+      declare -g "_${b}"="$(type -p "${b}")"
+    else
+      echo >&2 "The executable ${b} is missing"
+      exit 1
+    fi
+  done
+}
+
+main() {
+  is_binary_available
+
+  for filename in "${ARGS[@]}"; do
+    # shellcheck disable=SC2154
+    "${_terradoc}" fmt -w "${filename}"
+  done
+}
+# Run script
+main

--- a/pre_commit_hooks/terradoc/generate.sh
+++ b/pre_commit_hooks/terradoc/generate.sh
@@ -1,11 +1,34 @@
 #!/usr/bin/env bash
 
 set -e
+set -u 
+set -o pipefail
 
-if ! command -v terradoc >/dev/null 2>&1; then
-  echo >&2 "terradoc is not available on this system."
-  echo >&2 "Please install it by running 'go install github.com/mineiros-io/terradoc/cmd/terradoc@latest'"
-  exit 1
-fi
+# shellcheck disable=SC2155,SC2034
+readonly ARGS=("$@")
 
-terradoc generate $1 -o $2
+function is_binary_available() {
+  local bin_list=( terradoc )
+  for b in "${bin_list[@]}"; do
+    if [ -x "$(type -p "${b}")" ]; then
+      declare -g "_${b}"="$(type -p "${b}")"
+    else
+      echo >&2 "The executable ${b} is missing"
+      exit 1
+    fi
+  done
+}
+
+main() {
+  is_binary_available
+
+  local filename_base=""
+
+  for filename in "${ARGS[@]}"; do
+    filename_base="$(basename "${filename}")"
+    # shellcheck disable=SC2154
+    "${_terradoc}" generate "${filename}" -o "$(dirname "${filename}")/${filename_base/.tfdoc.hcl/.md}"
+  done
+}
+# Run script
+main

--- a/pre_commit_hooks/terradoc/validate.sh
+++ b/pre_commit_hooks/terradoc/validate.sh
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
 
 set -e
+set -u 
+set -o pipefail
 
-if ! command -v terradoc >/dev/null 2>&1; then
-  echo >&2 "terradoc is not available on this system."
-  echo >&2 "Please install it by running 'go install github.com/mineiros-io/terradoc/cmd/terradoc@latest'"
-  exit 1
-fi
+# shellcheck disable=SC2155,SC2034
+readonly ARGS=("$@")
 
-terradoc validate $1
+function is_binary_available() {
+  local bin_list=( terradoc )
+  for b in "${bin_list[@]}"; do
+    if [ -x "$(type -p "${b}")" ]; then
+      declare -g "_${b}"="$(type -p "${b}")"
+    else
+      echo >&2 "The executable ${b} is missing"
+      exit 1
+    fi
+  done
+}
+
+main() {
+  is_binary_available
+
+  local filename="${ARGS[0]}"
+  echo "$filename"
+  # shellcheck disable=SC2154
+  "${_terradoc}" validate "${filename}"
+}
+# Run script
+main


### PR DESCRIPTION
Hi, This is a suggestion to add recursive support to `terradoc fmt` and `terradoc generate`.

- [x] updated `fmt.sh` to handle a recursive list of files
- [x] updated `generate.sh` to handle a recursive list of files
- [x] updated `.pre-commit-config.yaml` with filters to capture only accepted files
- [x] added some basic Bash error handling in `.pre-commit-hooks/terradoc/*`
- [x] updated README to match the Terradoc features

This update does not break existing functionality for `terradoc`.