### PR TITLE
fix: update tflint script to accept newer versions

### DIFF
--- a/pre_commit_hooks/terraform/tflint.sh
+++ b/pre_commit_hooks/terraform/tflint.sh
@@ -2,6 +2,22 @@
 
 set -e
 
-for file in "$@"; do
-  tflint "$file"
-done
+if ! command -v tflint >/dev/null 2>&1; then
+  echo >&2 "tflint is not available on this system."
+  echo >&2 "Please visit https://github.com/terraform-linters/tflint for instructions on how to install."
+  exit 1
+fi
+
+tflint_version=$(tflint -v | awk 'NR==1 { print $3 }' | awk -F. '{ print $1"."$2 }')
+max_old_version="0.46"
+
+if [[ $(tflint -v | awk -vmaxv=$max_old_version 'NR==1 { version=$3; if(version > maxv){print "true"} }') == "true" ]]; then
+  if [[ ! -n "$CI" ]]; then
+    tflint --init
+  fi
+  tflint
+else
+  for file in "$@"; do
+    tflint "$file"
+  done
+fi


### PR DESCRIPTION
Usage of tflint has changed since 0.47 ("command line arguments support was dropped").

Also for providers, tflint now requires a configuration file (e.g. plugin for google) that has to be initialized with `tflint --init`.
For the CI runs, it will require github token to avoid rate-limiting, that's why the 'init' happens only locally.
In the script, if the tflint version is >= 0.47, it will just run `tflint` on the root dir.